### PR TITLE
Dot spacemacs edits

### DIFF
--- a/emacs/spacemacs.symlink
+++ b/emacs/spacemacs.symlink
@@ -479,6 +479,10 @@ before packages are loaded."
 
   ;; Consider _ to be part of a word in Ruby
   (add-hook 'ruby-mode-hook #'(lambda () (modify-syntax-entry ?_ "w")))
+
+  (global-set-key (kbd "C-c C-p") 'previous-buffer)
+  (global-set-key (kbd "C-c C-n") 'next-buffer)
+
   ;; Disable lockfiles (those pesky .# files)
   (setq create-lockfiles nil)
 

--- a/emacs/spacemacs.symlink
+++ b/emacs/spacemacs.symlink
@@ -471,6 +471,8 @@ before packages are loaded."
 
   ;; TODO: Use (kbd ...) instead of [(control ?_) ...] for key bindings
 
+  ;; Consider _ to be part of a word in Ruby
+  (add-hook 'ruby-mode-hook #'(lambda () (modify-syntax-entry ?_ "w")))
   ;; Disable lockfiles (those pesky .# files)
   (setq create-lockfiles nil)
 

--- a/emacs/spacemacs.symlink
+++ b/emacs/spacemacs.symlink
@@ -70,7 +70,10 @@ This function should only modify configuration layer settings."
    ;; wrapped in a layer. If you need some configuration for these
    ;; packages, then consider creating a layer. You can also put the
    ;; configuration in `dotspacemacs/user-config'.
-   dotspacemacs-additional-packages '(helm-ag multiple-cursors)
+   dotspacemacs-additional-packages '(helm-ag multiple-cursors
+                                              ;; Solarized theme
+                                              ;;  color-theme-solarized
+                                              )
    ;; A list of packages that cannot be updated.
    dotspacemacs-frozen-packages '()
 
@@ -470,6 +473,9 @@ Put your configuration code here, except for variables that should be set
 before packages are loaded."
 
   ;; TODO: Use (kbd ...) instead of [(control ?_) ...] for key bindings
+
+  ;; Solarized theme
+  ;; (set-terminal-parameter nil 'background-mode 'dark) (set-frame-parameter nil 'background-mode 'dark) (spacemacs/load-theme 'solarized)
 
   ;; Consider _ to be part of a word in Ruby
   (add-hook 'ruby-mode-hook #'(lambda () (modify-syntax-entry ?_ "w")))


### PR DESCRIPTION
* Using word keys in `ruby-mode` considers underscores to be part of the word
* Add support for solarized theme
* `C-c C-n` to go to next buffer
* `C-c C-p` to go to previous buffer